### PR TITLE
Corretta installazione del framework nel Dockerfile

### DIFF
--- a/Dockerfile/Dockerfile
+++ b/Dockerfile/Dockerfile
@@ -17,6 +17,7 @@ RUN make all install JCC='python -m jcc' ANT=ant PYTHON=python NUM_FILES=8
 WORKDIR /usr/src
 RUN rm -rf pylucene
 
-COPY setup.py requirements.txt README.md /usr/src
+COPY . /usr/src/repo
 
-RUN pip install wheel sphinx networkx lenskit && python setup.py install
+WORKDIR /usr/src/repo
+RUN pip install wheel sphinx networkx lenskit && python repo/setup.py install

--- a/Dockerfile/Dockerfile
+++ b/Dockerfile/Dockerfile
@@ -20,4 +20,4 @@ RUN rm -rf pylucene
 COPY . /usr/src/repo
 
 WORKDIR /usr/src/repo
-RUN pip install wheel sphinx networkx lenskit && python repo/setup.py install
+RUN pip install wheel sphinx networkx lenskit && python setup.py install


### PR DESCRIPTION
closes #9. Per eseguire una corretta installazione del framework nella Docker Image, viene effettuata la copia in essa del repository