### PR TITLE
Cambio da unittest a pytest

### DIFF
--- a/.github/workflows/build&test&push.yml
+++ b/.github/workflows/build&test&push.yml
@@ -72,7 +72,7 @@ jobs:
                |
                 container_id=$(docker run -d -v "$(pwd)":/usr/src -it  ${{ secrets.DOCKER_USERNAME }}/${{ env.IMAGE_NAME }})
                 docker exec -i $container_id pip install coverage coveralls pytest
-                docker exec -i $container_id coverage run --source=orange_cb_recsys -m unittest
+                docker exec -i $container_id coverage run --source=orange_cb_recsys -m pytest
                 docker exec -i $container_id bash -c "COVERALLS_REPO_TOKEN=${{ env.COVERALLS_REPO_TOKEN }} coveralls"
                 docker stop $container_id
                 docker container rm $container_id


### PR DESCRIPTION
`pytest` dà errore se vengono eseguiti 0 test, `unittest` invece no. Inoltre `pytest` è più supportato, ha più plugin ed è completamente retrocompatibile quindi non va riscritto nessun test. Closes #14 