### PR TITLE
Risolto errore SVM con pochi item locali e esplicata meglio condizione non soddisfatta

### DIFF
--- a/orange_cb_recsys/recsys/ranking_algorithms/classifier.py
+++ b/orange_cb_recsys/recsys/ranking_algorithms/classifier.py
@@ -192,10 +192,19 @@ class ClassifierRecommender(RankingAlgorithm):
 
         elif self.__classifier.lower() == "svm":
             if self.__classifier_parameters is not None:
-                clf = CalibratedClassifierCV(LinearSVC(**self.__classifier_parameters))
+                try:
+                    n_fold = self.__check_svm(labels)
+                    clf = CalibratedClassifierCV(SVC(kernel='linear', probability=True, **self.__classifier_parameters),
+                                                 cv=n_fold)
+                except ValueError:
+                    clf = SVC(kernel='linear', probability=True, **self.__classifier_parameters)
             else:
-                n_fold = self.__check_svm(labels)
-                clf = CalibratedClassifierCV(LinearSVC(random_state=42), cv=n_fold)
+                try:
+                    n_fold = self.__check_svm(labels)
+                    clf = CalibratedClassifierCV(SVC(kernel='linear', probability=True),
+                                                 cv=n_fold)
+                except ValueError:
+                    clf = SVC(kernel='linear', probability=True)
 
         elif self.__classifier.lower() == "log_regr":
             if self.__classifier_parameters is not None:

--- a/orange_cb_recsys/recsys/ranking_algorithms/classifier.py
+++ b/orange_cb_recsys/recsys/ranking_algorithms/classifier.py
@@ -125,8 +125,10 @@ class ClassifierRecommender(RankingAlgorithm):
 
         if len(labels) == 0:
             raise FileNotFoundError("No rated item available locally!")
-        if 0 not in labels or 1 not in labels:
-            raise ValueError("There's only positive or negative items available locally!")
+        if 0 not in labels:
+            raise ValueError("There are only positive items available locally!")
+        elif 1 not in labels:
+            raise ValueError("There are only negative items available locally!")
 
         return labels
 

--- a/orange_cb_recsys/recsys/ranking_algorithms/classifier.py
+++ b/orange_cb_recsys/recsys/ranking_algorithms/classifier.py
@@ -1,7 +1,6 @@
 import collections
 from typing import List, Dict
 
-from scipy import sparse
 from sklearn import neighbors
 from sklearn.calibration import CalibratedClassifierCV
 from sklearn.ensemble import RandomForestClassifier
@@ -10,7 +9,7 @@ from sklearn.gaussian_process import GaussianProcessClassifier
 from sklearn.linear_model import LogisticRegression
 from sklearn.pipeline import make_pipeline
 from sklearn.preprocessing import FunctionTransformer
-from sklearn.svm import LinearSVC
+from sklearn.svm import SVC
 from sklearn.tree import DecisionTreeClassifier
 
 from orange_cb_recsys.content_analyzer.content_representation.content import Content


### PR DESCRIPTION
closes #29. Risolto il problema del calssificatore svm con pochi rating disponibili in locale. Se ci sono le condizioni per eseguire la _cross validation_ e calibrare meglio il classificatore, allora viene calibrato meglio, altrimenti no.

Inoltre è stato modularizzata e documentata la parte del calcolo di item positivi/negativi.
Infine, ogni classificatore funziona se e solo se:

- Sono presenti item valutati **in locale**
- E' presente _ALMENO_ un item **negativo** e _ALMENO_ un item **positivo** in locale.

Se non sono soddisfatte entrambe le condizioni, il classificatore non può funzionare e a tal proposito è stato esplicato meglio con messaggi di errore quale condizione non risulta soddisfatta.