### PR TITLE
Fix page rank in ordine decrescente e fix calcolo score normalizzato

### DIFF
--- a/orange_cb_recsys/recsys/graphs/graph.py
+++ b/orange_cb_recsys/recsys/graphs/graph.py
@@ -45,7 +45,15 @@ class Graph(ABC):
         Returns:
             float in the range [0.0, 1.0]
         """
-        return 1 - (score + 1) / 2
+        old_max = 1
+        old_min = -1
+        new_max = 1
+        new_min = 0
+
+        old_range = (old_max - old_min)
+        new_range = (new_max - new_min)
+        new_value = (((score - old_min) * new_range) / old_range) + new_min
+        return new_value
 
     @property
     def source_frame(self):

--- a/orange_cb_recsys/recsys/ranking_algorithms/page_rank.py
+++ b/orange_cb_recsys/recsys/ranking_algorithms/page_rank.py
@@ -49,7 +49,7 @@ class PageRankAlg(RankingAlgorithm):
                 new_rank.pop(k)
             if remove_profile and self.__fullgraph.is_to_node(k) and k in extracted_profile.keys():
                 new_rank.pop(k)
-            if remove_properties and not self.__fullgraph.is_to_node(k) and not self.__fullgraph.is_from_node(k):
+            if remove_properties and self.__fullgraph.is_exogenous_property(k):
                 new_rank.pop(k)
         return new_rank
 

--- a/orange_cb_recsys/recsys/ranking_algorithms/page_rank.py
+++ b/orange_cb_recsys/recsys/ranking_algorithms/page_rank.py
@@ -89,6 +89,7 @@ class NXPageRank(PageRankAlg):
             scores = nx.pagerank(self.fullgraph.graph)
         # clean the results removing user nodes, selected user profile and eventually properties
         scores = self.clean_rank(scores, user_id)
+        scores = dict(sorted(scores.items(), key=lambda item: item[1], reverse=True))
         ks = list(scores.keys())
         ks = ks[:recs_number]
         new_scores = {k: scores[k] for k in scores.keys() if k in ks}

--- a/test/recsys/ranking_algorithms/test_page_rank.py
+++ b/test/recsys/ranking_algorithms/test_page_rank.py
@@ -1,16 +1,11 @@
-import lzma
-import os
 import pandas as pd
 from unittest import TestCase
 
 from orange_cb_recsys.recsys import NXPageRank
+from orange_cb_recsys.recsys.graphs.full_graphs import NXFullGraph
 from orange_cb_recsys.utils.const import logger
 
-
-class TestNXPageRank(TestCase):
-    def test_predict(self):
-        alg = NXPageRank()
-        ratings = pd.DataFrame.from_records([
+ratings = pd.DataFrame.from_records([
             ("A000", "tt0114576", 0.5, "54654675"),
             ("A000", "tt0112453", -0.5, "54654675"),
             ("A001", "tt0114576", 0.8, "54654675"),
@@ -21,15 +16,35 @@ class TestNXPageRank(TestCase):
             ("A003", "tt0112453", -0.8, "54654675")],
             columns=["from_id", "to_id", "score", "timestamp"])
 
-        try:
-            path = "../../../contents/movielens_test1591885241.5520566"
-            file = os.path.join(path, "tt0114576.xz")
-            with lzma.open(file, "r") as content_file:
-                pass
-        except FileNotFoundError:
-            path = "contents/movielens_test1591885241.5520566"
+graph = NXFullGraph(ratings)
+alg = NXPageRank(graph=graph)
 
-        rank = alg.predict('A000', ratings, 1, path, ['tt0114576'])
+class TestNXPageRank(TestCase):
+    def test_predict(self):
+        rank = alg.predict('A001', ratings, 1)
         logger.info('pg_rk results')
         for r in rank.keys():
-            logger.info('%s %s', str(r), str(rank[r]))
+            print(str(r) + " " + str(rank[r]))
+
+        self.assertIn('tt0112453', rank.keys())
+
+class PageRankAlg(TestCase):
+    def test_clean_rank(self):
+        rank = {"A000": 0.5, "tt0114576": 0.5, "A001": 0.5, "tt0113497": 0.5, "tt0112453": 0.5}
+
+        # remove from rank all from nodes
+        result = alg.clean_rank(rank, user_id="A000", remove_profile=False, remove_from_nodes=True)
+        expected = {"tt0114576": 0.5, "tt0113497": 0.5, "tt0112453": 0.5}
+        self.assertEqual(expected, result)
+
+        # remove from rank all from nodes and all data from user A000
+        result = alg.clean_rank(rank, user_id="A000", remove_profile=True, remove_from_nodes=True)
+        expected = {"tt0113497": 0.5}
+        self.assertEqual(expected, result)
+
+    def test_extract_profile(self):
+        result = alg.extract_profile("A000")
+
+        expected = {'tt0114576': 0.75, 'tt0112453': 0.25, 'tt0113041': 0.8}
+
+        self.assertEqual(expected, result)


### PR DESCRIPTION
Closes #41. Sono stati creati anche ulteriori test per il page rank.
Inoltre fix calcolo score normalizzato come indicato nel [commento](https://github.com/Silleellie/orange_cb_recsys/issues/39#issuecomment-778638861) di #39 