### PR TITLE
Omessi file di esempio da coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,7 @@
 [run]
 omit =
     */online/*
+    *example*
 
 [report]
 exclude_lines =


### PR DESCRIPTION
Come da titolo, in quanto le funzionalità presenti nei file di esempio sono già testate singolarmente nei file di test appropriati