### PR TITLE
Risolto bug per funzionamento preprocessor multipli

### DIFF
--- a/orange_cb_recsys/content_analyzer/information_processor/nlp.py
+++ b/orange_cb_recsys/content_analyzer/information_processor/nlp.py
@@ -9,6 +9,7 @@ from nltk.corpus import wordnet
 from nltk.stem.snowball import SnowballStemmer
 
 from orange_cb_recsys.content_analyzer.information_processor.information_processor import NLP
+from orange_cb_recsys.utils.check_tokenization import check_not_tokenized
 
 
 def get_wordnet_pos(word):
@@ -249,6 +250,7 @@ class NLTK(NLP):
         return text
 
     def process(self, field_data) -> List[str]:
+        field_data = check_not_tokenized(field_data)
         if self.strip_multiple_whitespaces:
             field_data = self.__strip_multiple_whitespaces_operation(field_data)
         if self.url_tagging:


### PR DESCRIPTION
Il bug in questione (definito in #61) era causato dal fatto che **NLTK** prenda come input una stringa da tokenizzare e fornisca in output una lista di token. Utilizzando due (o anche più) istanze di NLTK, il primo non avrà problemi, ma il secondo avrà in input una lista di token fornita in output dal primo e lancerà eccezione.
Prima dell'inizio del processing di NLTK è stata quindi aggiunta un'operazione di detokenizzazione (per permettere anche il corretto funzionamento di operazioni, come _strip_multiple_whitespaces_, che si aspettano una stringa come input).

Closes #61 