### PR TITLE
Aggiunto metodo query per IndexInterface

### DIFF
--- a/orange_cb_recsys/content_analyzer/memory_interfaces/memory_interfaces.py
+++ b/orange_cb_recsys/content_analyzer/memory_interfaces/memory_interfaces.py
@@ -176,5 +176,10 @@ class TextInterface(InformationInterface):
         raise NotImplementedError
 
     @abstractmethod
+    def query(self, string_query: str, results_number: int, mask_list: list = None,
+              candidate_list: list = None, classic_similarity: bool = True) -> dict:
+        raise NotImplementedError
+
+    @abstractmethod
     def get_tf_idf(self, field_name: str, content_id: Union[str, int]):
         raise NotImplementedError

--- a/test/content_analyzer/memory_interfaces/test_text_interface.py
+++ b/test/content_analyzer/memory_interfaces/test_text_interface.py
@@ -118,3 +118,29 @@ class TestIndexInterface(TestCase):
         finally:
             index.delete()
 
+    def test_query(self):
+        index = SearchIndex("testing_query")
+        try:
+            index.init_writing()
+            index.new_content()
+            index.new_field("content_id", "0")
+            index.new_field("test1", "this is a test for the query on the index")
+            index.new_field("test2", "this is the second field")
+            index.serialize_content()
+            index.new_content()
+            index.new_field("content_id", "1")
+            index.new_field("test1", "field")
+            index.serialize_content()
+            index.new_content()
+            index.new_field("content_id", "2")
+            index.new_field("test1", "query on the index")
+            index.serialize_content()
+            index.stop_writing()
+
+            # test for querying the index
+            result = index.query("test1:(query on the index)", 2, ["2"], ["0", "1"], True)
+            self.assertEqual(len(result), 1)
+            self.assertEqual(result["0"]["item"]["test1"], "this is a test for the query on the index")
+        finally:
+            index.delete()
+


### PR DESCRIPTION
Completata la realizzazione del metodo _query_ all'interno di **IndexInterface**. Grazie a questo metodo, algoritmi di recommending come **IndexQuery** non dovranno più caricare i contenuti in memoria ma potranno direttamente effettuare le interrogazioni sull'indice.

Il metodo è stato anche aggiunto come metodo astratto nella classe padre di IndexInterface (**TextInterface**), per permettere le stesse operazioni anche su altri indici testuali diversi da quello implementato da Whoosh.

Closes #71 