### PR TITLE
Fix unicode error for pandas query

### DIFF
--- a/.github/workflows/build&test&push.yml
+++ b/.github/workflows/build&test&push.yml
@@ -1,8 +1,9 @@
 name: Build & Test & Push
-on: 
+on:
   push:
+    branches:
+      - master
   pull_request:
-    types: [opened]
     
 env:
     IMAGE_NAME: framework_dependencies

--- a/orange_cb_recsys/evaluation/metrics/plot_metrics.py
+++ b/orange_cb_recsys/evaluation/metrics/plot_metrics.py
@@ -175,8 +175,8 @@ class PopProfileVsRecs(GroupFairnessMetric, PlotMetric):
         data_to_plot = []
         labels = []
         for group_name in user_groups:
-            truth_group = truth.query('from_id in @user_groups[@group_name]')
-            pred_group = predictions.query('from_id in @user_groups[@group_name]')
+            truth_group = truth.query('from_id in @user_groups[@group_name]', engine='python')
+            pred_group = predictions.query('from_id in @user_groups[@group_name]', engine='python')
 
             profile_pop_ratios_frame = pop_ratio_by_user(truth_group, most_popular_items)
             recs_pop_ratios_frame = pop_ratio_by_user(pred_group, most_popular_items)


### PR DESCRIPTION
Quando sulla macchina è installato numexpr, la libreria pandas usa come engine di default per le sue query proprio 'numexpr', che però non supporta alcune query complesse. Va specificato manualmente l'engine 'python' per suddette query complesse.