### PR TITLE
Rimosso attributo index_document_id non utilizzato da Content

### DIFF
--- a/orange_cb_recsys/content_analyzer/content_analyzer_main.py
+++ b/orange_cb_recsys/content_analyzer/content_analyzer_main.py
@@ -246,6 +246,7 @@ class ContentsProducer:
                     for field_name in index_representations_dict[memory_interface].keys():
                         memory_interface.new_field(
                             field_name, str(index_representations_dict[memory_interface][field_name][i].value))
+                    memory_interface.serialize_content()
                 memory_interface.stop_writing()
             self.__memory_interfaces.clear()
 

--- a/orange_cb_recsys/content_analyzer/content_analyzer_main.py
+++ b/orange_cb_recsys/content_analyzer/content_analyzer_main.py
@@ -246,7 +246,6 @@ class ContentsProducer:
                     for field_name in index_representations_dict[memory_interface].keys():
                         memory_interface.new_field(
                             field_name, str(index_representations_dict[memory_interface][field_name][i].value))
-                    contents_list[i].index_document_id = memory_interface.serialize_content()
                 memory_interface.stop_writing()
             self.__memory_interfaces.clear()
 

--- a/orange_cb_recsys/content_analyzer/content_representation/content.py
+++ b/orange_cb_recsys/content_analyzer/content_representation/content.py
@@ -207,7 +207,6 @@ class Content:
         self.__content_id: str = content_id
         self.__field_dict: Dict[str, RepresentationContainer] = field_dict
         self.__exogenous_rep_container: RepresentationContainer = exogenous_rep_container
-        self.__index_document_id: int = None  # to be removed
 
     @property
     def content_id(self):
@@ -215,14 +214,6 @@ class Content:
         Getter for the content id
         """
         return self.__content_id
-
-    @property
-    def index_document_id(self) -> int:
-        return self.__index_document_id
-
-    @index_document_id.setter
-    def index_document_id(self, index_document_id: int):
-        self.__index_document_id = index_document_id
 
     @property
     def field_dict(self):


### PR DESCRIPTION
Rimosso attributo diventato inutile dopo le modifiche apportate a ContentAnalyzer e RecSys