### PR TITLE
Rimosso RuntimeWarning lanciato durante il calcolo della similarità del coseno

### DIFF
--- a/orange_cb_recsys/recsys/content_based_algorithm/centroid_vector/similarities.py
+++ b/orange_cb_recsys/recsys/content_based_algorithm/centroid_vector/similarities.py
@@ -30,6 +30,9 @@ class CosineSimilarity(Similarity):
         Calculates the cosine similarity between v1 and v2
         """
 
-        # Cosine_distance is defined in the scipy library as 1 - cosine_similarity, so:
-        # 1 - cosine_distance = 1 - (1 - cosine_similarity) = cosine_similarity
-        return 1 - cosine_distance(v1, v2)
+        if not v1.any() or not v2.any():
+            return 0
+        else:
+            # Cosine_distance is defined in the scipy library as 1 - cosine_similarity, so:
+            # 1 - cosine_distance = 1 - (1 - cosine_similarity) = cosine_similarity
+            return 1 - cosine_distance(v1, v2)

--- a/test/recsys/content_based_algorithm/centroid_vector/test_similarities.py
+++ b/test/recsys/content_based_algorithm/centroid_vector/test_similarities.py
@@ -5,8 +5,28 @@ import numpy as np
 
 class TestCosineSimilarity(TestCase):
     def test_perform(self):
+        sim = CosineSimilarity()
+
         a = np.array([5, 9, 7, 8, 3, 5, 4, 2, 6, 4])
         b = np.array([8, 1, 3, 10, 8, 4, 9, 2, 1, 6])
-        sim = CosineSimilarity()
-        self.assertAlmostEqual(sim.perform(a, b),
-                         0.7552110293516224)
+        self.assertAlmostEqual(sim.perform(a, b), 0.7552110293516224)
+
+        a = np.array([0, 0, 0])
+        b = np.array([1, 1, 1])
+        self.assertEqual(sim.perform(a, b), 0)
+
+        a = np.array([1, 1, 1])
+        b = np.array([0, 0, 0])
+        self.assertEqual(sim.perform(a, b), 0)
+
+        a = np.array([0, 0, 0])
+        b = np.array([0, 0, 0])
+        self.assertEqual(sim.perform(a, b), 0)
+
+        a = np.array([1, 1, 1])
+        b = np.array([1, 1, 1])
+        self.assertEqual(sim.perform(a, b), 1)
+
+        a = np.array([1, 1, 1])
+        b = np.array([-1, -1, -1])
+        self.assertEqual(sim.perform(a, b), -1)


### PR DESCRIPTION
La classe CosineSimilarity permette il calcolo della similarità del coseno usando la funzione _cosine_distance_ di **scipy**. Tuttavia, spesso accadeva che venisse lanciato un warning che avvisava di un valore non valido incontrato durante il calcolo. Questo era dovuto alla possibile presenza di vettori nulli (ovvero contenenti solo 0). Questo scenario poteva anche portare, in alcuni casi, a restituire valori errati.

Per ovviare al problema, si è aggiunto un controllo prima del calcolo della similarità del coseno che, nel caso uno dei due vettori sia nullo, ritorna semplicemente 0.